### PR TITLE
Handle an ethereum address instead of pubkey

### DIFF
--- a/src/surface/__main__.py
+++ b/src/surface/__main__.py
@@ -46,10 +46,11 @@ def start(datadir, provider, network):
     core_socket = core.IPC(CONFIG['IPC_HOST'], CONFIG['IPC_PORT'])
     core_socket.connect()
     results_json = core_socket.get_report()
-    signing_key = results_json['pub_key']
+    signing_address = results_json['address']
     quote = ias.Quote.from_enigma_proxy(
         results_json['quote'], server=CONFIG['IAS_PROXY'])
-    log.info('ECDSA Signing Key: {}'.format(signing_key))
+    log.info('ECDSA Signing address: {}'.format(signing_address))
+    log.info('ECDSA Signing address from Quote: {}'.format(quote.report_body.report_data.rstrip(b'\x00').decode()))
 
     # 1.2 Commit the quote to the Enigma Smart Contract
     account, w3 = utils.unlock_wallet(provider, network, CONFIG['WORKER_ID'])
@@ -64,7 +65,7 @@ def start(datadir, provider, network):
         account=account,
         contract=eng_contract,
         token=token_contract,
-        ecdsa_pubkey=bytes.fromhex(signing_key),
+        ecdsa_address=signing_address,
         quote=quote)
 
     report, sig, cert = quote.serialize()

--- a/src/surface/communication/core/worker.py
+++ b/src/surface/communication/core/worker.py
@@ -6,14 +6,13 @@ from web3 import Web3
 from surface.communication.ethereum.utils import parse_arg_types, event_data
 from surface.communication.ias import Quote
 import rlp
-from eth_keys import keys
 
 log = Logger('Worker')
 
 
 class Worker:
     # TODO: we should have the report only once, we can remove the quote from init
-    def __init__(self, account, contract, token, ecdsa_pubkey,
+    def __init__(self, account, contract, token, ecdsa_address,
                  quote: Quote = ''):
         """
         The worker is in charge of managing the tasks and talking to core.
@@ -25,9 +24,7 @@ class Worker:
         self.account = account
         self.contract = contract
         self.token = token
-        self._ecdsa_pubkey = keys.PublicKey(ecdsa_pubkey)
-
-        self.signer = self._ecdsa_pubkey.to_checksum_address()
+        self.ecdsa_address = Web3.toChecksumAddress(ecdsa_address)
 
         self._quote = quote
         self.encoded_report = None
@@ -36,10 +33,6 @@ class Worker:
     @property
     def quote(self):
         return self._quote
-
-    @property
-    def ecdsa_pubkey(self):
-        return self._ecdsa_pubkey.to_hex()
 
     @property
     def workers_params(self):
@@ -102,10 +95,11 @@ class Worker:
         :return:
         """
         log.info('registering account: {}'.format(self.account))
+        log.info('registering Report: {}'.format(report))
         encoded_report = rlp.encode([report, report_cert, sig])
 
         tx = self.contract.functions.register(
-            self.signer, encoded_report
+            self.ecdsa_address, encoded_report
         ).transact({'from': self.account})
 
         return tx

--- a/src/tests/fixtures.py
+++ b/src/tests/fixtures.py
@@ -140,13 +140,14 @@ def principal(w3, contract, principal_data, token_contract):
     priv_bytes = bytearray.fromhex(principal_data['signing_priv_key'])
     priv = SigningKey.from_string(priv_bytes, curve=SECP256k1)
     pub = priv.get_verifying_key().to_string()
+    address = '0x' + Web3.sha3(hexstr=pub.hex()).hex()[-40:]
 
     account = w3.personal.listAccounts[9]
     principal = Worker(
         account=account,
         contract=contract,
         token=token_contract,
-        ecdsa_pubkey=pub,
+        ecdsa_address=address,
         quote=principal_data['quote'],
     )
     yield principal
@@ -158,13 +159,14 @@ def worker(w3, contract, workers_data, token_contract):
         priv_bytes = bytearray.fromhex(worker_data['signing_priv_key'])
         priv = SigningKey.from_string(priv_bytes, curve=SECP256k1)
         pub = priv.get_verifying_key().to_string()
+        address = '0x' + Web3.sha3(hexstr=pub.hex()).hex()[-40:]
 
         account = w3.personal.listAccounts[index]
         worker = Worker(
             account=account,
             contract=contract,
             token=token_contract,
-            ecdsa_pubkey=pub,
+            ecdsa_address=address,
             quote=worker_data['quote'],
         )
         yield worker

--- a/src/tests/test_ipc_worker.py
+++ b/src/tests/test_ipc_worker.py
@@ -21,13 +21,13 @@ preprocessors = [b'rand()']
 def test_trip_to_core(w3, contract, token_contract, dapp_contract):
     core_socket.connect()
     results_json = core_socket.get_report()
-    pubkey = results_json['pub_key']
+    address = results_json['address']
     quote = Quote.from_enigma_proxy(results_json['quote'], server='https://sgx.enigma.co/api')
     worker = Worker(
         account=w3.personal.listAccounts[0],
         contract=contract,
         token=token_contract,
-        ecdsa_pubkey=bytes.fromhex(pubkey),
+        ecdsa_address=address,
         quote=quote
     )
     tx = worker.register(

--- a/src/tests/test_trigger.py
+++ b/src/tests/test_trigger.py
@@ -28,7 +28,7 @@ def test_trigger(w3, dapp_contract, token_contract, contract):
         account=w3.personal.listAccounts[0],
         contract=contract,
         token=token_contract,
-        ecdsa_pubkey=b'0000000000000000000000000000000000000000000000000000000000000000',
+        ecdsa_address='0x0000000000000000000000000000000000000000',
         quote=''
     )
     tx = worker.trigger_compute_task(
@@ -62,7 +62,7 @@ def test_billionare(w3, token_contract, contract, config):
         account=account,
         contract=contract,
         token=token_contract,
-        ecdsa_pubkey=b'0000000000000000000000000000000000000000000000000000000000000000',
+        ecdsa_address='0x0000000000000000000000000000000000000000',
         quote=''
     )
     tx = worker.trigger_compute_task(


### PR DESCRIPTION
This is required after the changes in `enigma-core` Iin this PR: https://github.com/enigmampc/enigma-core/pull/6
Because now it receives an Ethereum address instead of a public key.

This too can't be merge before coordinating with the Dapp JS.

